### PR TITLE
Fix up purchasing upgrades.

### DIFF
--- a/src/components/custom/game/components/v2/Cart.tsx
+++ b/src/components/custom/game/components/v2/Cart.tsx
@@ -32,7 +32,9 @@ export const Cart: FC<CartProps> = ({}) => {
 		<div className="mt-4 p-5 border-2 font-mono justify-self-center">
 			<div className="pb-10 justify-self-center">Upgrades Purchased this Prestige:</div>
 			{cartVisible ? (
-				<div className="w-full h-[350px] overflow-y-scroll">
+				<div
+					className={`${gameStateRef.current.userUpgrades.length > 0 ? 'w-full h-[350px] overflow-y-scroll' : 'w-full'}`}
+				>
 					{gameStateV2.userUpgrades
 						.filter((f) => f.prestige_num == gameStateV2.user.num_times_prestiged)
 						.map((u) => (
@@ -94,13 +96,17 @@ export const Cart: FC<CartProps> = ({}) => {
 			) : (
 				<></>
 			)}
-			<div className="flex justify-center">
-				<Button
-					variant={cartVisible ? 'secondary' : 'destructive'}
-					onClick={() => setCartVisible((prev) => !prev)}
-				>
-					Toggle Cart
-				</Button>
+			<div className="flex justify-center pt-5">
+				{gameStateRef.current.userUpgrades.length > 0 ? (
+					<Button
+						variant={cartVisible ? 'secondary' : 'destructive'}
+						onClick={() => setCartVisible((prev) => !prev)}
+					>
+						Toggle Cart
+					</Button>
+				) : (
+					<></>
+				)}
 			</div>
 		</div>
 	);

--- a/src/components/custom/game/components/v2/ChipV2.tsx
+++ b/src/components/custom/game/components/v2/ChipV2.tsx
@@ -14,16 +14,22 @@ interface ChipPropsV2 {
 export const ChipV2: FC<ChipPropsV2> = ({ upgrade, resources }) => {
 	const [gameStateV2] = useAtom(gameStateV2Atom);
 	const [pp] = useAtom(purchasePowerAtom);
-	if (resources >= getCostV2(upgrade, gameStateV2, pp)) {
-		if (calculateLocalLevel(upgrade, gameStateV2) >= upgrade.level_max) {
-			// Max level
-			return (
-				<Badge variant="chip" className={`opacity-85 bg-stone-800 hover:bg-stone-800/90 text-foreground`}>
-					Max Level
-				</Badge>
-			);
-		}
-		// Can Purchase
+
+	const currentLevel = calculateLocalLevel(upgrade, gameStateV2);
+	const maxPossiblePurchase = Math.max(0, upgrade.level_max - currentLevel);
+	const actualPurchaseAmount = Math.min(pp, maxPossiblePurchase);
+
+	// Check if already at max level
+	if (currentLevel >= upgrade.level_max) {
+		return (
+			<Badge variant="chip" className={`opacity-85 bg-stone-800 hover:bg-stone-800/90 text-foreground`}>
+				Max Level
+			</Badge>
+		);
+	}
+
+	// Check if can afford the actual purchasable amount
+	if (actualPurchaseAmount > 0 && resources >= getCostV2(upgrade, gameStateV2, actualPurchaseAmount)) {
 		return (
 			<Badge variant="chip" className={`opacity-85 bg-green-800 hover:bg-green-700/90 text-foreground`}>
 				Click Me!

--- a/src/components/custom/game/components/v2/PrestigeButtonV2.tsx
+++ b/src/components/custom/game/components/v2/PrestigeButtonV2.tsx
@@ -32,7 +32,6 @@ export const PrestigeButtonV2: FC<PrestigeButtonV2Props> = ({ initialState }) =>
 						(u.currency_per_second_inc >= 0 ? u.currency_per_second_inc * level_current : 0),
 				};
 			}
-			console.log(bonuses);
 		});
 		return bonuses;
 	};

--- a/src/components/custom/game/components/v2/UpgradesV2.tsx
+++ b/src/components/custom/game/components/v2/UpgradesV2.tsx
@@ -31,19 +31,57 @@ export const UpgradesV2: FC<UpgradeItemPropsV2> = ({ upgradeType }) => {
 	for (let keys of data) {
 		costs[keys.upgrade_id] = getCostV2(keys, gameStateV2, purchasePower);
 	}
+
+	const getActualPurchaseAmount = (upgrade: Upgrade): number => {
+		const currentLevel = calculateLocalLevel(upgrade, gameStateV2);
+		const maxPossiblePurchase = upgrade.level_max - currentLevel;
+		return Math.min(purchasePower, Math.max(0, maxPossiblePurchase));
+	};
+
+	// Helper function to check if an upgrade can be purchased
+	const canPurchaseUpgrade = (upgrade: Upgrade): boolean => {
+		const currentLevel = calculateLocalLevel(upgrade, gameStateV2);
+		const actualPurchaseAmount = getActualPurchaseAmount(upgrade);
+
+		// Can't purchase if already at max level or if actual purchase amount is 0
+		if (currentLevel >= upgrade.level_max || actualPurchaseAmount <= 0) {
+			return false;
+		}
+
+		// Check if can afford the cost
+		const cost = getCostV2(upgrade, gameStateV2, actualPurchaseAmount);
+		return resources >= cost;
+	};
+
 	const handleUpgrade = (upgrade: Upgrade) => {
+		const currentLevel = calculateLocalLevel(upgrade, gameStateV2);
+		const actualPurchaseAmount = getActualPurchaseAmount(upgrade);
+
+		// Double-check that we can make this purchase
+		if (actualPurchaseAmount <= 0 || currentLevel >= upgrade.level_max) {
+			toast.error('Cannot purchase: upgrade is already at maximum level!');
+			return;
+		}
+
+		const actualCost = getCostV2(upgrade, gameStateV2, actualPurchaseAmount);
+
+		if (resources < actualCost) {
+			toast.error('Cannot afford this upgrade!');
+			return;
+		}
+
 		const result: UserUpgrade = {
 			id: v4(),
 			user_id: sessionStorage.getItem('user_id')!,
 			upgrade_id: upgrade.upgrade_id,
-			level_current: calculateLocalLevel(upgrade, gameStateV2) + purchasePower,
+			level_current: currentLevel + actualPurchaseAmount,
 			prestige_num: gameStateV2.user.num_times_prestiged,
 			purchased_at: new Date().toISOString(),
 		};
-		costs[upgrade.upgrade_id] = getCostV2(upgrade, gameStateV2, purchasePower);
+
 		if (result.user_id === userID) {
 			console.log(result);
-			toast.success('Purchased Upgrade(s)!');
+			toast.success(`Purchased ${actualPurchaseAmount} level(s) of ${upgrade.upgrade_name}!`);
 			setGameState((state) => {
 				return {
 					...state,
@@ -51,16 +89,16 @@ export const UpgradesV2: FC<UpgradeItemPropsV2> = ({ upgradeType }) => {
 						...state.user,
 						currency_balance:
 							upgrade.upgrade_type === 'base'
-								? gameStateV2.user.currency_balance - costs[upgrade.upgrade_id]
+								? gameStateV2.user.currency_balance - actualCost
 								: gameStateV2.user.currency_balance,
 						currency_per_second:
-							state.user.currency_per_second + upgrade.currency_per_second_inc * purchasePower,
-						currency_per_click: state.user.currency_per_click + upgrade.cpc_inc * purchasePower,
+							state.user.currency_per_second + upgrade.currency_per_second_inc * actualPurchaseAmount,
+						currency_per_click: state.user.currency_per_click + upgrade.cpc_inc * actualPurchaseAmount,
 						currency_per_click_mult:
-							state.user.currency_per_click_mult + upgrade.cpc_mult_inc * purchasePower,
+							state.user.currency_per_click_mult + upgrade.cpc_mult_inc * actualPurchaseAmount,
 						prestige_points_balance:
 							upgrade.upgrade_type === 'prestige'
-								? gameStateV2.user.prestige_points_balance - costs[upgrade.upgrade_id]
+								? gameStateV2.user.prestige_points_balance - actualCost
 								: gameStateV2.user.prestige_points_balance,
 						last_seen: new Date().toISOString(),
 					},
@@ -71,139 +109,152 @@ export const UpgradesV2: FC<UpgradeItemPropsV2> = ({ upgradeType }) => {
 			toast.warning('Purchase failed!');
 		}
 	};
+
 	return (
 		<div>
-			{data.map((upgrade) => (
-				<div className="flex grid-flow-col gap-5 font-mono" key={upgrade.upgrade_id}>
-					<div>
-						<Accordion type="single" collapsible>
-							<AccordionItem value={upgrade.upgrade_name}>
-								<AccordionTrigger className="hover:bg-muted/50 px-5">
-									<div className="grid grid-cols-4 grid-rows-1 gap-2">
-										<div className="w-[200px]">{upgrade.upgrade_name}</div>
+			{data.map((upgrade) => {
+				const currentLevel = calculateLocalLevel(upgrade, gameStateV2);
+				const actualPurchaseAmount = getActualPurchaseAmount(upgrade);
+				const actualCost = actualPurchaseAmount > 0 ? getCostV2(upgrade, gameStateV2, actualPurchaseAmount) : 0;
+
+				return (
+					<div className="flex grid-flow-col gap-5 font-mono" key={upgrade.upgrade_id}>
+						<div>
+							<Accordion type="single" collapsible>
+								<AccordionItem value={upgrade.upgrade_name}>
+									<AccordionTrigger className="hover:bg-muted/50 px-5">
+										<div className="grid grid-cols-4 grid-rows-1 gap-2">
+											<div className="w-[200px]">{upgrade.upgrade_name}</div>
+											<div>
+												Level:{' '}
+												<span className="code max-w-fit px-2 hover:bg-primary-foreground hover:text-foreground">
+													{currentLevel} / {upgrade.level_max}
+												</span>
+											</div>
+											<div>
+												Cost:{' '}
+												<span className="code max-w-fit px-2 hover:bg-primary-foreground hover:text-foreground">
+													{actualCost.toLocaleString('en-us', {
+														maximumFractionDigits: 2,
+													})}
+												</span>
+											</div>
+											<div>
+												<ChipV2
+													upgrade={upgrade}
+													resources={
+														upgrade.upgrade_type === 'base'
+															? gameStateV2.user.currency_balance
+															: gameStateV2.user.prestige_points_balance
+													}
+												/>
+											</div>
+										</div>
+									</AccordionTrigger>
+									<AccordionContent className="pt-5">
 										<div>
-											Level:{' '}
-											<span className="code max-w-fit px-2 hover:bg-primary-foreground hover:text-foreground">
-												{calculateLocalLevel(upgrade, gameStateV2)} / {upgrade.level_max}
-											</span>
+											<legend className="font-mono">Upgrade Description</legend>
+											<div className="max-w-[550px] border-2 p-2 mt-2 font-mono italic text-xs overflow-scroll">
+												{upgrade.upgrade_desc}
+											</div>
 										</div>
-										<div>
-											Cost:{' '}
-											<span className="code max-w-fit px-2 hover:bg-primary-foreground hover:text-foreground">
-												{costs[upgrade.upgrade_id].toLocaleString('en-us', {
-													maximumFractionDigits: 2,
-												})}
-											</span>
-										</div>
-										<div>
-											<ChipV2
-												upgrade={upgrade}
-												resources={
-													upgrade.upgrade_type === 'base'
-														? gameStateV2.user.currency_balance
-														: gameStateV2.user.prestige_points_balance
-												}
-											/>
-										</div>
-									</div>
-								</AccordionTrigger>
-								<AccordionContent className="pt-5">
-									<div>
-										<legend className="font-mono">Upgrade Description</legend>
-										<div className="max-w-[550px] border-2 p-2 mt-2 font-mono italic text-xs overflow-scroll">
-											{upgrade.upgrade_desc}
-										</div>
-									</div>
-									<Table>
-										<TableHeader>
-											<TableRow>
-												<TableHead>Click Power Increase</TableHead>
-												<TableHead>Click Power Multiplier Increase</TableHead>
-												<TableHead>Currency Per Second Increase</TableHead>
-											</TableRow>
-										</TableHeader>
-										<TableBody>
-											<TableRow>
-												<TableCell>
-													<TooltipProvider>
-														<Tooltip>
-															<TooltipTrigger asChild>
-																<div className="code max-w-fit px-2 hover:bg-primary-foreground hover:text-foreground">
-																	+{(upgrade.cpc_inc * purchasePower).toFixed(2)}
-																</div>
-															</TooltipTrigger>
-															<TooltipContent className="bg-background border-2 text-foreground max-w-[240px]">
-																<div>
-																	Current Bonus: +
-																	{gameStateV2.user.currency_per_click} Currency/Click
-																</div>
-															</TooltipContent>
-														</Tooltip>
-													</TooltipProvider>
-												</TableCell>
-												<TableCell>
-													<TooltipProvider>
-														<Tooltip>
-															<TooltipTrigger asChild>
-																<div className="code max-w-fit px-2 hover:bg-primary-foreground hover:text-foreground">
-																	+{(upgrade.cpc_mult_inc * purchasePower).toFixed(2)}
-																	x
-																</div>
-															</TooltipTrigger>
-															<TooltipContent className="bg-background border-2 text-foreground max-w-[240px]">
-																<div>
-																	Current Bonus:{' '}
-																	{gameStateV2.user.currency_per_click_mult}x Currency
-																	per Click
-																</div>
-															</TooltipContent>
-														</Tooltip>
-													</TooltipProvider>
-												</TableCell>
-												<TableCell>
-													<TooltipProvider>
-														<Tooltip>
-															<TooltipTrigger asChild>
-																<div className="code max-w-fit px-2 hover:bg-primary-foreground hover:text-foreground">
-																	+
-																	{(
-																		upgrade.currency_per_second_inc * purchasePower
-																	).toFixed(2)}
-																	/s
-																</div>
-															</TooltipTrigger>
-															<TooltipContent className="font-medium bg-background border-2 text-foreground">
-																<div>
-																	Current Bonus: +
-																	{gameStateV2.user.currency_per_second} Currency/s{' '}
-																	<span className="spoiler">
-																		this is a rounded value
-																	</span>
-																</div>
-															</TooltipContent>
-														</Tooltip>
-													</TooltipProvider>
-												</TableCell>
-											</TableRow>
-										</TableBody>
-									</Table>
-								</AccordionContent>
-							</AccordionItem>
-						</Accordion>
+										<Table>
+											<TableHeader>
+												<TableRow>
+													<TableHead>Click Power Increase</TableHead>
+													<TableHead>Click Power Multiplier Increase</TableHead>
+													<TableHead>Currency Per Second Increase</TableHead>
+												</TableRow>
+											</TableHeader>
+											<TableBody>
+												<TableRow>
+													<TableCell>
+														<TooltipProvider>
+															<Tooltip>
+																<TooltipTrigger asChild>
+																	<div className="code max-w-fit px-2 hover:bg-primary-foreground hover:text-foreground">
+																		+
+																		{(
+																			upgrade.cpc_inc * actualPurchaseAmount
+																		).toFixed(2)}
+																	</div>
+																</TooltipTrigger>
+																<TooltipContent className="bg-background border-2 text-foreground max-w-[240px]">
+																	<div>
+																		Current Bonus: +
+																		{gameStateV2.user.currency_per_click}{' '}
+																		Currency/Click
+																	</div>
+																</TooltipContent>
+															</Tooltip>
+														</TooltipProvider>
+													</TableCell>
+													<TableCell>
+														<TooltipProvider>
+															<Tooltip>
+																<TooltipTrigger asChild>
+																	<div className="code max-w-fit px-2 hover:bg-primary-foreground hover:text-foreground">
+																		+
+																		{(
+																			upgrade.cpc_mult_inc * actualPurchaseAmount
+																		).toFixed(2)}
+																		x
+																	</div>
+																</TooltipTrigger>
+																<TooltipContent className="bg-background border-2 text-foreground max-w-[240px]">
+																	<div>
+																		Current Bonus:{' '}
+																		{gameStateV2.user.currency_per_click_mult}x
+																		Currency per Click
+																	</div>
+																</TooltipContent>
+															</Tooltip>
+														</TooltipProvider>
+													</TableCell>
+													<TableCell>
+														<TooltipProvider>
+															<Tooltip>
+																<TooltipTrigger asChild>
+																	<div className="code max-w-fit px-2 hover:bg-primary-foreground hover:text-foreground">
+																		+
+																		{(
+																			upgrade.currency_per_second_inc *
+																			actualPurchaseAmount
+																		).toFixed(2)}
+																		/s
+																	</div>
+																</TooltipTrigger>
+																<TooltipContent className="font-medium bg-background border-2 text-foreground">
+																	<div>
+																		Current Bonus: +
+																		{gameStateV2.user.currency_per_second}{' '}
+																		Currency/s{' '}
+																		<span className="spoiler">
+																			this is a rounded value
+																		</span>
+																	</div>
+																</TooltipContent>
+															</Tooltip>
+														</TooltipProvider>
+													</TableCell>
+												</TableRow>
+											</TableBody>
+										</Table>
+									</AccordionContent>
+								</AccordionItem>
+							</Accordion>
+						</div>
+						<div className="grid grid-cols-2 gap-5 max-w-fit content-center">
+							<Button disabled={!canPurchaseUpgrade(upgrade)} onClick={() => handleUpgrade(upgrade)}>
+								Buy Upgrade
+								{actualPurchaseAmount !== purchasePower && actualPurchaseAmount > 0 && (
+									<span className="text-xs ml-1">({actualPurchaseAmount})</span>
+								)}
+							</Button>
+						</div>
 					</div>
-					<div className="grid grid-cols-2 gap-5 max-w-fit content-center">
-						<Button
-							disabled={
-								resources < getCostV2(upgrade, gameStateV2, purchasePower) &&
-								calculateLocalLevel(upgrade, gameStateV2) != upgrade.level_max
-							}
-							onClick={() => handleUpgrade(upgrade)}
-						>
-							Buy Upgrade
-						</Button>
-					</div>
-				</div>
-			))}
+				);
+			})}
 		</div>
 	);
 };

--- a/src/components/custom/game/components/v2/util/util.ts
+++ b/src/components/custom/game/components/v2/util/util.ts
@@ -2,18 +2,25 @@ import { calculateLocalLevel } from '@/db/functions';
 import { Upgrade, GameStateV2 } from './v2-schema';
 
 export const getCostV2 = (upgrade: Upgrade, gameStateV2: GameStateV2, purchasePower: number): number => {
-	let cost = upgrade.cost;
-	let current_level: number = calculateLocalLevel(upgrade, gameStateV2);
-	if (current_level === 0 && purchasePower === 1) {
-		return cost;
-	} else {
-		for (let i = 0; i < current_level; i++) {
-			cost *= upgrade.cost_mult;
-		}
-		cost = cost * purchasePower;
+	const currentLevel = calculateLocalLevel(upgrade, gameStateV2);
+
+	let totalCost = 0;
+	let baseCost = upgrade.cost;
+
+	// Calculate base cost at current level
+	for (let i = 0; i < currentLevel; i++) {
+		baseCost *= upgrade.cost_mult;
 	}
-	return cost;
+
+	// Calculate cost for each additional level we want to purchase
+	for (let i = 0; i < purchasePower; i++) {
+		totalCost += baseCost;
+		baseCost *= upgrade.cost_mult;
+	}
+
+	return totalCost;
 };
+
 export const handleNewPrestigePoints = (gameStateV2: GameStateV2) => {
 	return Math.floor(gameStateV2.user.currency_balance / gameStateV2.user.prestige_cost);
 };

--- a/src/db/functions.ts
+++ b/src/db/functions.ts
@@ -51,7 +51,6 @@ export const fetchAndValidateGameState = async (): Promise<GameStateV2 | undefin
 
 	const validated = GameStateV2.safeParse(gameStateV2);
 	if (validated.success) {
-		console.log('Validated GameStateV2');
 		return gameStateV2;
 	}
 };


### PR DESCRIPTION
Changelog:

 - You can never purchase more levels than the maximum allows
 - The cost calculation properly accounts for the escalating cost of each level
 - All components (`ChipV2`, `UpgradesV2`) use consistent logic
 - Prestige points can never go negative
 - Users get clear feedback about what they're actually purchasing